### PR TITLE
Consider the capabilities of GB anisotropy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ MISC                        := no
 NAVIER_STOKES               := no
 OPTIMIZATION                := no
 PERIDYNAMICS                := no
-PHASE_FIELD                 := no
+PHASE_FIELD                 := yes
 POROUS_FLOW                 := no
 RAY_TRACING                 := no
 REACTOR                     := no
@@ -48,7 +48,7 @@ RDG                         := no
 RICHARDS                    := no
 STOCHASTIC_TOOLS            := no
 THERMAL_HYDRAULICS          := no
-TENSOR_MECHANICS            := no
+TENSOR_MECHANICS            := yes
 XFEM                        := no
 
 include $(MOOSE_DIR)/modules/modules.mk

--- a/baize.yaml
+++ b/baize.yaml
@@ -1,0 +1,8 @@
+DMETHOD: opt
+compiler_type: gcc
+documentation: true
+installation_type: in_tree
+registered_apps:
+- WASPAPP
+- BAIZETESTAPP
+- BAIZEAPP

--- a/calculation_cases/p1_copperThinFilm_AGG_2022/p1_noteBook.md
+++ b/calculation_cases/p1_copperThinFilm_AGG_2022/p1_noteBook.md
@@ -1,0 +1,12 @@
+> 论文: https://www.sciencedirect.com/science/article/pii/S1359645423005669?via%3Dihub
+
+# 介绍及建模
+
+# 双晶模拟
+
+# 大尺度多晶模拟
+
+# 小尺度多晶模拟
+
+# 其他
+

--- a/include/materials/grain_growth/GBAnisotropyMisori.h
+++ b/include/materials/grain_growth/GBAnisotropyMisori.h
@@ -1,0 +1,66 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "GBAnisotropyMisoriBase.h"
+
+#include "EulerAngleProvider.h"
+#include "GrainTracker.h"
+#include "MisoriAngleCalculator.h"
+
+// Forward Declarations
+
+/**
+ * GBAnisotropyMisoriBase is created based on GrainTracker for real-time acquisition of
+ * sigma_ij, mob_ij based on misorientation angle.
+ * function 1: GB anisotropy based classic theroies
+ * function 2: Low-energy and low-mobility properties of twin interfaces
+ */
+class GBAnisotropyMisori : public GBAnisotropyMisoriBase
+{
+public:
+  static InputParameters validParams();
+
+  GBAnisotropyMisori(const InputParameters & parameters);
+
+protected:
+  // Set sigma_ij, mob_ij, Q_ij for specific grain boundaries
+  virtual void computeGBProperties() override;
+
+  // calculated GB energy based on the the Read-Shockley
+  virtual Real calculatedGBEnergy(const MisorientationAngleData & misori_s);
+
+  // calculated GB mobility based on the sigmoidal law
+  virtual Real calculatedGBMobility(const MisorientationAngleData & misori_s);
+
+  // used to store orientation structure, including misorientation angle, istwinnig, twinning type;
+  MisorientationAngleData _misori_s;
+  
+  // for HCP_Ti
+  const Real _TT1_sigma;
+  const Real _CT1_sigma;
+  const Real _TT1_mob;
+  const Real _CT1_mob;
+
+  // for FCC_Ni
+  const Real _Sigma3_sigma;
+  const Real _Sigma9_sigma;
+  const Real _Sigma3_mob;
+  const Real _Sigma9_mob;
+
+  const GrainTracker & _grain_tracker;
+  const EulerAngleProvider & _euler; 
+
+  const bool _gb_energy_anisotropy;
+  const bool _gb_mobility_anisotropy;    
+
+  MaterialProperty<Real> & _misori_angle;
+  MaterialProperty<Real> & _twinning_type;
+};

--- a/include/materials/grain_growth/GBAnisotropyMisoriBase.h
+++ b/include/materials/grain_growth/GBAnisotropyMisoriBase.h
@@ -1,0 +1,75 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Material.h"
+
+// Forward Declarations
+
+/**
+ * Function[kappa, gamma, m, L] = parameters (sigma, mob, w_GB, sigma0)
+ * Parameter determination method is elaborated in Phys. Rev. B, 78(2), 024113, 2008, by N. Moelans
+ * Thanks to Prof. Moelans for the explanation of her paper.
+ */
+class GBAnisotropyMisoriBase : public Material
+{
+public:
+  static InputParameters validParams();
+
+  GBAnisotropyMisoriBase(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  // Set sigma_ij, mob_ij, Q_ij based on misorientation angle
+  virtual void computeGBProperties();
+
+  // Calculate the model parameters for the phase field
+  virtual void computerPFParameters();
+
+  // Interpolate phase field model parameters
+  virtual void interpolatePFParams();
+
+  virtual void computerPFGBIsotropy();
+
+  const unsigned int _mesh_dimension;
+
+  const Real _length_scale;
+  const Real _time_scale;
+  const Real _GBsigma_HAGB;
+  const Real _GBmob_HAGB;
+  const Real _Q_HAGB;
+  const Real _wGB;
+  const Real _scale_factor_matrix;
+
+  const FileName _Anisotropic_GB_file_name;
+
+  const VariableValue & _T;
+
+  std::vector<std::vector<Real>> _sigma;
+  std::vector<std::vector<Real>> _mob;
+  std::vector<std::vector<Real>> _Q;
+  std::vector<std::vector<Real>> _kappa_gamma;
+  std::vector<std::vector<Real>> _a_g2;
+
+  MaterialProperty<Real> & _kappa;
+  MaterialProperty<Real> & _gamma;
+  MaterialProperty<Real> & _L;
+  MaterialProperty<Real> & _mu;
+
+  const Real _kb;
+  const Real _JtoeV;
+  Real _mu_qp;
+
+  const unsigned int _op_num;
+
+  const std::vector<const VariableValue *> _vals;
+  const std::vector<const VariableGradient *> _grad_vals;
+};

--- a/include/utils/MisoriAngleCalculator.h
+++ b/include/utils/MisoriAngleCalculator.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "Moose.h"
+#include "EulerAngles.h"
+#include "EulerAngleProvider.h"
+
+typedef Eigen::Quaternion<Real> QuatReal;
+
+// set twin type
+enum class TwinType {Sigma3_FCC, Sigma9_FCC, TT1_HCP, CT1_HCP, NONE};
+
+// set the key orientation type
+enum class QuatType {getTwinning, getSSymm, getCSymm};
+
+// Set the typical crystallographic structure
+enum class CrystalType {FCC, BCC, HCP};
+
+struct MisorientationAngleData{Real _misor = -1.0; bool _is_twin = false; TwinType _twin_type = TwinType::NONE;};
+
+/**
+ * This is an orientation difference calculator, inspired by MTEX.
+ * However, it is an incomplete version and needs further optimization TODO.
+ */
+namespace MisoriAngleCalculator
+{
+  // function 1: input Euler1 and Euler2, output s
+  MisorientationAngleData calculateMisorientaion(EulerAngles & Euler1, EulerAngles & Euler2, MisorientationAngleData & s, const CrystalType & crystal_type = CrystalType::HCP);  
+
+  // function 2: Obtaining the key orientation using quaternion, including twinning, CS, SS
+  std::vector<QuatReal> getKeyQuat(const QuatType & quat_type, const CrystalType & crystal_type = CrystalType::HCP);
+
+  // function 3.1: computer the scalar dot product using quaternion
+  Real dotQuaternion(const QuatReal & o1, const QuatReal & o2, 
+                     const std::vector<QuatReal> & qcs, 
+                     const std::vector<QuatReal> & qss);
+
+  // function 3.2: computes inv(o1) .* o2 usig quaternion
+  QuatReal itimesQuaternion(const QuatReal & q1, const QuatReal & q2);
+
+  // function 3.3: computes outer inner product between two quaternions
+  Real dotOuterQuaternion(const QuatReal & rot1, const std::vector<QuatReal> & rot2);
+
+  // function 3.4: X*Y is the matrix product of X and Y. ~twice~
+  Real mtimes2Quaternion(const QuatReal & q1, const std::vector<QuatReal> & q2, const QuatReal & qTwin);  
+}

--- a/src/materials/grain_growth/GBAnisotropyMisori.C
+++ b/src/materials/grain_growth/GBAnisotropyMisori.C
@@ -1,0 +1,233 @@
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "GBAnisotropyMisori.h"
+#include "MooseMesh.h"
+#include <cmath>
+
+registerMooseObject("baizeApp", GBAnisotropyMisori);
+
+InputParameters
+GBAnisotropyMisori::validParams()
+{
+  InputParameters params = GBAnisotropyMisoriBase::validParams();
+  params.addClassDescription(
+      "Computes necessary material properties for the anisotropic grain growth model");
+  params.addParam<Real>("TT1_sigma",  0.9, "Twin boundary energy for {10-12} tensile twin (type 1) based on MD, J/m^2");
+  params.addParam<Real>("CT1_sigma",  0.9, "Twin boundary energy for {11-22} compresssion twin (type 1) based on MD, J/m^2");  
+  params.addParam<Real>("TT1_mob", 2.5e-6, "Twin boundary mobility for {10-12} tensile twin (type 1) based on experiment, m^4/(J*s)");
+  params.addParam<Real>("CT1_mob", 2.5e-6, "Twin boundary mobility for {11-22} compresssion twin (type 1) based on experiment, m^4/(J*s)");
+  params.addParam<Real>("Sigma9_sigma",  0.9, "Twin boundary energy for {10-12} tensile twin (type 1) based on MD, J/m^2");
+  params.addParam<Real>("Sigma3_sigma",  0.9, "Twin boundary energy for {11-22} compresssion twin (type 1) based on MD, J/m^2");  
+  params.addParam<Real>("Sigma9_mob", 2.5e-6, "Twin boundary mobility for {10-12} tensile twin (type 1) based on experiment, m^4/(J*s)");
+  params.addParam<Real>("Sigma3_mob", 2.5e-6, "Twin boundary mobility for {11-22} compresssion twin (type 1) based on experiment, m^4/(J*s)");
+  params.addRequiredParam<UserObjectName>(
+      "grain_tracker", "Name of GrainTracker user object that provides Grain ID according to element ID");
+  params.addRequiredParam<UserObjectName>("euler_angle_provider",
+                                          "Name of Euler angle provider user object");
+  params.addParam<bool>("gb_energy_anisotropy", false,
+      "The GB energy anisotropy based on misorientation would be considered if true");
+  params.addParam<bool>("gb_mobility_anisotropy", true,
+      "The GB mobility anisotropy would be considered if true");                                          
+  return params;
+
+  // TODO - 添加晶体类型到输出参数中， FCC BCC HCP
+}
+
+GBAnisotropyMisori::GBAnisotropyMisori(const InputParameters & parameters)
+  : GBAnisotropyMisoriBase(parameters),
+    _TT1_sigma(getParam<Real>("TT1_sigma")),
+    _CT1_sigma(getParam<Real>("CT1_sigma")),
+    _TT1_mob(getParam<Real>("TT1_mob")),
+    _CT1_mob(getParam<Real>("CT1_mob")),
+    _Sigma3_sigma(getParam<Real>("Sigma3_sigma")),
+    _Sigma9_sigma(getParam<Real>("Sigma9_sigma")),
+    _Sigma3_mob(getParam<Real>("Sigma3_mob")),
+    _Sigma9_mob(getParam<Real>("Sigma9_mob")),
+    _grain_tracker(getUserObject<GrainTracker>("grain_tracker")),
+    _euler(getUserObject<EulerAngleProvider>("euler_angle_provider")),
+    _gb_energy_anisotropy(getParam<bool>("gb_energy_anisotropy")),
+    _gb_mobility_anisotropy(getParam<bool>("gb_mobility_anisotropy")),
+    _misori_angle(declareProperty<Real>("misori_angle")),
+    _twinning_type(declareProperty<Real>("twinning_type"))  
+{
+}
+
+void
+GBAnisotropyMisori::computeGBProperties()
+{
+  auto & time_current = _fe_problem.time();
+
+  _misori_angle[_qp] = 0.0;
+  _twinning_type[_qp] = -1.0;
+
+  // get the GB location based on the GrainTracker in the quadrature point
+  const auto & op_to_grains = _grain_tracker.getVarToFeatureVector(_current_elem->id()); 
+
+  std::vector<unsigned int> var_index;
+  std::vector<unsigned int> grain_id_index;
+  for (MooseIndex(op_to_grains) op_index = 0; op_index < op_to_grains.size(); ++op_index)
+  {
+    auto grain_id = op_to_grains[op_index]; // grain id
+
+    if (grain_id == FeatureFloodCount::invalid_id)
+      continue;
+
+    var_index.push_back(op_index);
+    grain_id_index.push_back(grain_id);
+  }
+   
+  Real sigma_min = _GBsigma_HAGB;
+  Real sigma_max = _GBsigma_HAGB;
+  Real mob_min = _GBmob_HAGB;
+  Real mob_max = _GBmob_HAGB;
+
+  // When at grain boundaries or junction
+  if (grain_id_index.size() > 1)
+  {
+    std::fill(_sigma.begin(), _sigma.end(), std::vector<Real>(_op_num, 0.0));
+    std::fill(_mob.begin(), _mob.end(), std::vector<Real>(_op_num, 0.0));
+
+    // Traverse to obtain the sigma_ij, mob_ij of the activation order parameters at the orthogonal point
+    for (unsigned int i = 0; i < grain_id_index.size() - 1; ++i)
+    {
+      auto angles_i = _euler.getEulerAngles(grain_id_index[i]);
+      for (unsigned int j = i+1; j < grain_id_index.size(); ++j)
+      {
+        auto angles_j = _euler.getEulerAngles(grain_id_index[j]);
+
+        auto & _sigma_ij = _sigma[var_index[i]][var_index[j]];
+        auto & _mob_ij = _mob[var_index[i]][var_index[j]];
+
+        // calculate misorientation angle
+        _misori_s = MisoriAngleCalculator::calculateMisorientaion(angles_i, angles_j, _misori_s, CrystalType::HCP);
+
+        if (_gb_energy_anisotropy && (time_current > 20.0))
+          _sigma_ij = calculatedGBEnergy(_misori_s);
+        else
+          _sigma_ij = _GBsigma_HAGB;
+
+        if (_gb_mobility_anisotropy && (time_current > 50.0))
+          _mob_ij = calculatedGBMobility(_misori_s);
+        else
+          _mob_ij = _GBmob_HAGB;
+
+        _sigma[var_index[j]][var_index[i]] =  _sigma_ij;
+        _mob[var_index[j]][var_index[i]] =  _mob_ij;
+
+        // Set the twinning type
+        if (i == 0 && j == 1)
+        {
+          _misori_angle[_qp] =  _misori_s._misor;
+
+          if (_misori_s._is_twin && (_misori_s._twin_type == TwinType::TT1_HCP))
+            _twinning_type[_qp] = 1.0;
+          else if (_misori_s._is_twin && (_misori_s._twin_type == TwinType::CT1_HCP))
+            _twinning_type[_qp] = 2.0;
+          if (_misori_s._is_twin && (_misori_s._twin_type == TwinType::Sigma3_FCC))
+            _twinning_type[_qp] = 3.0;
+          else if (_misori_s._is_twin && (_misori_s._twin_type == TwinType::Sigma9_FCC))
+            _twinning_type[_qp] = 4.0;
+          else
+            _twinning_type[_qp] = 0.0; // GB
+
+          sigma_min = _sigma_ij;
+          sigma_max = _sigma_ij;
+
+          mob_min = _mob_ij;          
+          mob_max = _mob_ij;
+        }
+
+        if (sigma_min > _sigma_ij)
+          sigma_min = _sigma_ij;
+        else if (sigma_max < _sigma_ij)
+          sigma_max = _sigma_ij;
+
+        if (mob_min > _mob_ij)
+          mob_min = _mob_ij;
+        else if (mob_max < _mob_ij)
+          mob_max = _mob_ij;
+      }
+    }
+
+    for (unsigned int i = 0; i < _op_num; ++i)
+      for (unsigned int j = 0; j < _op_num; ++j)
+      {
+        if ((_sigma[i][j] == 0.0))
+        {
+          _sigma[i][j] = (sigma_max + sigma_min) / 2.0;
+          _sigma[j][i] = (sigma_max + sigma_min) / 2.0;
+        }
+
+        if ((_mob[i][j] == 0.0))
+        {
+          _mob[i][j] = (mob_max + mob_min) / 2.0;
+          _mob[j][i] = (mob_max + mob_min) / 2.0;
+        }
+      }
+  }
+}
+
+Real
+GBAnisotropyMisori::calculatedGBEnergy(const MisorientationAngleData & misori_s)
+{
+  Real gbSigma = _GBsigma_HAGB;
+
+  // transition misorientation angle between low and high-angle grain boundary
+  Real trans_misori_angle_HAGB = 15.0;
+
+  if ((_misori_s._misor <= 1.0) && !misori_s._is_twin)
+    gbSigma = _GBsigma_HAGB * ((2.0 / trans_misori_angle_HAGB * (1 - std::log(2.0 / trans_misori_angle_HAGB))));    
+  else if ((_misori_s._misor <= trans_misori_angle_HAGB) && !misori_s._is_twin)
+    gbSigma = _GBsigma_HAGB * ((misori_s._misor / trans_misori_angle_HAGB * (1 - std::log(misori_s._misor / trans_misori_angle_HAGB))));
+  else if (misori_s._is_twin)
+  {
+    if (misori_s._twin_type == TwinType::TT1_HCP)
+      gbSigma = _TT1_sigma;
+    else if (misori_s._twin_type == TwinType::CT1_HCP)
+      gbSigma = _CT1_sigma;
+    else if (misori_s._twin_type == TwinType::Sigma3_FCC)
+      gbSigma =  _Sigma3_sigma;
+    else if (misori_s._twin_type == TwinType::Sigma9_FCC)
+      gbSigma =  _Sigma9_sigma;
+  }
+
+  return gbSigma; 
+}
+ 
+Real
+GBAnisotropyMisori::calculatedGBMobility(const MisorientationAngleData & misori_s)
+{
+  // Initialize GB mobility
+  Real gbMob = _GBmob_HAGB;
+
+  // transition misorientation angle between low and high-angle grain boundary
+  Real trans_misori_angle_HAGB = 15;
+
+  // Equation constant
+  Real B = 5;
+  Real n = 4;
+  
+  if ((_misori_s._misor <= 1.0) && !misori_s._is_twin)
+    gbMob = _GBmob_HAGB * ((1- std::exp(-B * std::pow( 2.0 / trans_misori_angle_HAGB, n)))); // Eq.8    
+  else if ((_misori_s._misor <=  trans_misori_angle_HAGB) && !misori_s._is_twin )
+    gbMob = _GBmob_HAGB * ((1- std::exp(-B * std::pow( misori_s._misor / trans_misori_angle_HAGB, n)))); // Eq.8
+  else if (misori_s._is_twin)
+  {
+    if (misori_s._twin_type == TwinType::TT1_HCP)
+      gbMob = _TT1_mob;
+    else if (misori_s._twin_type == TwinType::CT1_HCP)
+      gbMob = _CT1_mob;
+    else if (misori_s._twin_type == TwinType::Sigma3_FCC)
+      gbMob = _Sigma3_mob;
+    else if (misori_s._twin_type == TwinType::Sigma9_FCC)
+      gbMob = _Sigma9_mob;
+  }
+
+  return gbMob;
+}

--- a/src/materials/grain_growth/GBAnisotropyMisoriBase.C
+++ b/src/materials/grain_growth/GBAnisotropyMisoriBase.C
@@ -1,0 +1,211 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "GBAnisotropyMisoriBase.h"
+#include "MooseMesh.h"
+
+registerMooseObject("qinglongApp", GBAnisotropyMisoriBase);
+
+InputParameters
+GBAnisotropyMisoriBase::validParams()
+{
+  InputParameters params = Material::validParams();
+  params.addCoupledVar("T", 300.0, "Temperature in Kelvin");
+  params.addParam<Real>("length_scale", 1.0e-9, "Length scale in m, where default is nm");
+  params.addParam<Real>("time_scale", 1.0e-9, "Time scale in s, where default is ns");
+  params.addParam<Real>("GBsigma_HAGB", 0.9, "GB energy of a high angle GB");
+  params.addParam<Real>("GBmob_HAGB", 2.5e-6, "GB mobility of a high angle GB");
+  params.addParam<Real>("Q_HAGB", 0.23, "initial value of Q, where default is eV");
+  params.addRequiredParam<Real>("wGB", "Diffuse GB width in nm");
+  params.addParam<Real>("scale_factor_matrix", 1.0e-2,"scale factor for matrix sigma or mob");
+  params.addRequiredCoupledVarWithAutoBuild(
+      "v", "var_name_base", "op_num", "Array of coupled variables");
+  return params;
+}
+
+GBAnisotropyMisoriBase::GBAnisotropyMisoriBase(const InputParameters & parameters)
+  : Material(parameters),
+    _mesh_dimension(_mesh.dimension()),
+    _length_scale(getParam<Real>("length_scale")),
+    _time_scale(getParam<Real>("time_scale")),
+    _GBsigma_HAGB(getParam<Real>("GBsigma_HAGB")),
+    _GBmob_HAGB(getParam<Real>("GBmob_HAGB")),
+    _Q_HAGB(getParam<Real>("Q_HAGB")),
+    _wGB(getParam<Real>("wGB")),
+    _scale_factor_matrix(getParam<Real>("scale_factor_matrix")),
+    _T(coupledValue("T")),
+    _kappa(declareProperty<Real>("kappa_op")),
+    _gamma(declareProperty<Real>("gamma_asymm")),
+    _L(declareProperty<Real>("L")),
+    _mu(declareProperty<Real>("mu")),
+    _kb(8.617343e-5),      // Boltzmann constant in eV/K
+    _JtoeV(6.24150974e18), // Joule to eV conversion
+    _mu_qp(0.0),
+    _op_num(coupledComponents("v")),
+    _vals(coupledValues("v")),
+    _grad_vals(coupledGradients("v"))
+{
+  // reshape vectors
+  _sigma.resize(_op_num);
+  _mob.resize(_op_num);
+  _Q.resize(_op_num);
+  _kappa_gamma.resize(_op_num);
+  _a_g2.resize(_op_num);
+
+  for (unsigned int op = 0; op < _op_num; ++op)
+  {
+    _sigma[op].resize(_op_num);
+    _mob[op].resize(_op_num);
+    _Q[op].resize(_op_num);
+    _kappa_gamma[op].resize(_op_num);
+    _a_g2[op].resize(_op_num);
+  }
+}
+
+void
+GBAnisotropyMisoriBase::computeQpProperties()
+{
+  // Initialize sigma_ij, mob_ij, Q_ij
+  std::fill(_sigma.begin(), _sigma.end(), std::vector<Real>(_op_num, _GBsigma_HAGB));
+  std::fill(_mob.begin(), _mob.end(), std::vector<Real>(_op_num, _GBmob_HAGB));
+  std::fill(_Q.begin(), _Q.end(), std::vector<Real>(_op_num, _Q_HAGB));
+
+  computeGBProperties();
+
+  // convert unit
+  for (unsigned int m = 0; m < _op_num - 1; ++m)
+    for (unsigned int n = m + 1; n < _op_num; ++n)
+    {
+      _sigma[m][n] *= _JtoeV * (_length_scale * _length_scale); // eV/nm^2
+
+      _mob[m][n] *= _time_scale / (_JtoeV * (_length_scale * _length_scale * _length_scale *
+                                             _length_scale)); // Convert to nm^4/(eV*ns);
+    } 
+
+    computerPFParameters();
+
+    interpolatePFParams();
+}
+
+void
+GBAnisotropyMisoriBase::computeGBProperties()
+{
+}
+
+void
+GBAnisotropyMisoriBase::computerPFParameters()
+{
+  Real sigma_init;
+  Real g2 = 0.0;
+  Real f_interf = 0.0;
+  Real a_0 = 0.75;
+  Real a_star = 0.0;
+  Real kappa_star = 0.0;
+  Real gamma_star = 0.0;
+  Real y = 0.0; // 1/gamma
+  Real yyy = 0.0;
+
+  Real sigma_big = 0.0;
+  Real sigma_small = 0.0;
+
+  for (unsigned int m = 0; m < _op_num - 1; ++m)
+    for (unsigned int n = m + 1; n < _op_num; ++n)
+    {
+      if (m == 0 && n == 1)
+      {
+        sigma_big = _sigma[m][n];
+        sigma_small = sigma_big;
+      }
+
+      else if (_sigma[m][n] > sigma_big)
+        sigma_big = _sigma[m][n];
+
+      else if (_sigma[m][n] < sigma_small)
+        sigma_small = _sigma[m][n];
+    }
+
+  sigma_init = (sigma_big + sigma_small) / 2.0;
+  _mu_qp = 6.0 * sigma_init / _wGB;
+
+  for (unsigned int m = 0; m < _op_num - 1; ++m)
+    for (unsigned int n = m + 1; n < _op_num; ++n) // m<n
+    {
+      a_star = a_0;
+      a_0 = 0.0;
+
+      while (std::abs(a_0 - a_star) > 1.0e-9)
+      {
+        a_0 = a_star;
+        kappa_star = a_0 * _wGB * _sigma[m][n];
+        g2 = _sigma[m][n] * _sigma[m][n] / (kappa_star * _mu_qp);
+        y = -5.288 * g2 * g2 * g2 * g2 - 0.09364 * g2 * g2 * g2 + 9.965 * g2 * g2 - 8.183 * g2 +
+            2.007;
+        gamma_star = 1 / y;
+        yyy = y * y * y;
+        f_interf = 0.05676 * yyy * yyy - 0.2924 * yyy * y * y + 0.6367 * yyy * y - 0.7749 * yyy +
+                   0.6107 * y * y - 0.4324 * y + 0.2792;
+        a_star = std::sqrt(f_interf / g2);
+      }
+
+      _kappa_gamma[m][n] = kappa_star; // upper triangle stores the discrete set of kappa values
+      _kappa_gamma[n][m] = gamma_star; // lower triangle stores the discrete set of gamma values
+
+      _a_g2[m][n] = a_star; // upper triangle stores "a" data.
+      _a_g2[n][m] = g2;     // lower triangle stores "g2" data.
+    }
+}
+
+void
+GBAnisotropyMisoriBase::interpolatePFParams()
+{
+  Real sum_kappa = 0.0;
+  Real sum_gamma = 0.0;
+  Real sum_L = 0.0;
+  Real Val = 0.0;
+  Real sum_val = 0.0;
+  Real f_sigma = 1.0;
+  Real f_mob = 1.0;
+  Real gamma_value = 0.0;
+
+  for (unsigned int m = 0; m < _op_num - 1; ++m)
+  {
+    for (unsigned int n = m + 1; n < _op_num; ++n) // m<n
+    {
+      gamma_value = _kappa_gamma[n][m];
+
+      Val = (100000.0 * ((*_vals[m])[_qp]) * ((*_vals[m])[_qp]) + 0.01) *
+            (100000.0 * ((*_vals[n])[_qp]) * ((*_vals[n])[_qp]) + 0.01);
+
+      sum_val += Val;
+      sum_kappa += _kappa_gamma[m][n] * f_sigma * Val;
+      sum_gamma += gamma_value * Val;
+      
+      // Following comes from substituting Eq. (36c) from the paper into (36b)
+      sum_L += Val * _mob[m][n] * std::exp(-_Q[m][n] / (_kb * _T[_qp])) * f_mob * _mu_qp * _a_g2[n][m] / _sigma[m][n];
+    }
+  }
+
+  _kappa[_qp] = sum_kappa / sum_val;
+  _gamma[_qp] = sum_gamma / sum_val;
+  _L[_qp] = sum_L / sum_val;
+  _mu[_qp] = _mu_qp;
+}
+
+void
+GBAnisotropyMisoriBase::computerPFGBIsotropy()
+{
+  const Real length_scale4 = _length_scale * _length_scale * _length_scale * _length_scale;
+  Real sigma_iso = _GBsigma_HAGB * _JtoeV * _length_scale * _length_scale;
+  Real mob_iso = _GBmob_HAGB * _time_scale / (_JtoeV * length_scale4) * std::exp(-_Q_HAGB / (_kb * _T[_qp]));
+
+  _kappa[_qp] = 3.0 / 4.0 * sigma_iso * _wGB;
+  _gamma[_qp] = 1.5;
+  _L[_qp] = 4.0 / 3.0 * mob_iso / _wGB;
+  _mu[_qp] = 3.0 / 4.0 * 1.0 / 0.125 * sigma_iso / _wGB;
+}

--- a/src/materials/grain_growth/GBAnisotropyMisoriBase.C
+++ b/src/materials/grain_growth/GBAnisotropyMisoriBase.C
@@ -10,7 +10,7 @@
 #include "GBAnisotropyMisoriBase.h"
 #include "MooseMesh.h"
 
-registerMooseObject("qinglongApp", GBAnisotropyMisoriBase);
+registerMooseObject("baizeApp", GBAnisotropyMisoriBase);
 
 InputParameters
 GBAnisotropyMisoriBase::validParams()

--- a/src/utils/MisoriAngleCalculator.C
+++ b/src/utils/MisoriAngleCalculator.C
@@ -1,0 +1,225 @@
+#include "MisoriAngleCalculator.h"
+
+namespace MisoriAngleCalculator
+{
+
+  MisorientationAngleData calculateMisorientaion(EulerAngles & Euler1, EulerAngles & Euler2, MisorientationAngleData & s, const CrystalType & crystal_type)
+  {
+    // a conversion from Radians to degrees
+    constexpr Real degree = 1.7453e-02;
+
+    // Tolerance for identifying twins
+    constexpr Real tolerance_mis = 3.90;
+
+    // Initialize the computed twin tolerance
+    Real misor_twinning = tolerance_mis + 1.0;
+
+    Real value_acos = 0.0;
+    const QuatReal & q1 = Euler1.toQuaternion();
+    const QuatReal & q2 = Euler2.toQuaternion();
+    const QuatReal mori_q1q2 = itimesQuaternion(q1, q2); // inv(q1)*q2
+
+    const std::vector<QuatReal> q3_twin = getKeyQuat(QuatType::getTwinning, crystal_type);
+    std::vector<QuatReal> qcs = getKeyQuat(QuatType::getCSymm, crystal_type);
+    std::vector<QuatReal> qss = getKeyQuat(QuatType::getSSymm);
+
+    // calculate misorientation angle
+    value_acos = dotQuaternion(q1, q2, qcs, qss);
+    if (value_acos <= 1.0 && value_acos >= -1.0)
+      s._misor = (Real)(2.0*std::acos(value_acos)/degree);
+    else
+      s._misor =  tolerance_mis + 1;
+
+    for (unsigned int i = 0; i < q3_twin.size(); ++i)
+    {
+      value_acos = dotQuaternion(mori_q1q2, q3_twin[i], qcs, qcs);
+      if (value_acos <= 1.0 && value_acos >= -1.0)
+        misor_twinning = (Real)(2.0*std::acos(value_acos)/degree);
+
+      s._is_twin = (bool)(misor_twinning < tolerance_mis); // Judging whether it is a twin boundary
+
+      // Determine which type of twin boundary 0 ~ TT1 (tensile twins), 1 ~ CT1 (compression twins)
+      if (s._is_twin && crystal_type == CrystalType::HCP)
+      {
+        if (i == 0)
+          s._twin_type = TwinType::TT1_HCP;
+        else if (i == 1)
+          s._twin_type = TwinType::CT1_HCP;
+
+        break;
+      }
+      else if (s._is_twin && crystal_type == CrystalType::FCC)
+      {
+        if (i == 0)
+          s._twin_type = TwinType::Sigma3_FCC;
+        else if (i == 1)
+          s._twin_type = TwinType::Sigma9_FCC;
+
+        break;        
+      }
+    }
+    return s;
+  }
+
+  std::vector<QuatReal> getKeyQuat(const QuatType & quat_type, const CrystalType & crystal_type)
+  {
+    std::vector<std::vector<Real>> q_num;
+
+    if (quat_type == QuatType::getTwinning && crystal_type == CrystalType::HCP)
+      q_num = {
+        {0.73728,  0.58508,  0.3378,  0}, // The quaternion corresponding to the crystallography orientation 
+        {0.84339,  0.53730,  0,       0}
+      };
+    else if (quat_type == QuatType::getTwinning && crystal_type == CrystalType::FCC)
+      q_num = {
+        {0.8660,  0.2887,  0.2887,  0.2887}, // Sigma3
+        {0.9428,  0.0,     0.2357,  0.2357} // Sigma9
+      };
+      // Quaternion for FCC twinning from MTEX;
+    else if (quat_type == QuatType::getSSymm)
+      q_num = {
+        {-1.000e+00,  0.000e+00,  0.000e+00, -2.220e-16}
+      }; // from MTEX;  
+    else if (quat_type == QuatType::getCSymm && crystal_type == CrystalType::HCP)
+      q_num = {
+        { 1.000e+00,  0.000e+00,  0.000e+00,  0.000e+00},
+        { 0.000e+00,  8.660e-01, -5.000e-01,  0.000e+00},
+        { 8.660e-01,  0.000e+00,  0.000e+00,  5.000e-01},
+        { 0.000e+00,  5.000e-01, -8.660e-01,  0.000e+00},
+        { 5.000e-01,  0.000e+00,  0.000e+00,  8.660e-01},
+        { 0.000e+00,  0.000e+00, -1.000e+00,  0.000e+00},
+        { 0.000e+00,  0.000e+00,  0.000e+00,  1.000e+00},
+        { 0.000e+00, -5.000e-01, -8.660e-01,  0.000e+00},
+        {-5.000e-01,  0.000e+00,  0.000e+00,  8.660e-01},
+        { 0.000e+00, -8.660e-01, -5.000e-01,  0.000e+00},
+        {-8.660e-01,  0.000e+00,  0.000e+00,  5.000e-01},
+        { 0.000e+00, -1.000e+00,  0.000e+00,  0.000e+00}
+      }; // 12 symmetric for hcp
+    else if (quat_type == QuatType::getCSymm && crystal_type == CrystalType::FCC)
+      q_num = {
+        { 1.000E+00,	 0.000E+00, 	 0.000E+00, 	 0.000E+00},
+        { 5.000E-01,	 5.000E-01, 	 5.000E-01, 	 5.000E-01},
+        {-5.000E-01,	 5.000E-01, 	 5.000E-01, 	 5.000E-01},
+        { 6.123E-17,	 7.071E-01, 	 7.071E-01, 	 8.660E-17},
+        {-7.071E-01,	 1.543E-16, 	 7.071E-01, 	 9.881E-17},
+        {-7.071E-01,	-7.071E-01, 	 2.343E-16, 	 1.221E-17},
+        { 7.071E-01,	 0.000E+00, 	 0.000E+00, 	 7.071E-01},
+        { 1.110E-16,	 7.071E-01, 	 3.925E-17, 	 7.071E-01},
+        {-7.071E-01,	 7.071E-01, 	 5.551E-17, 	 2.680E-16},
+        {-1.793E-17,	 1.000E+00, 	 8.865E-17, 	 1.045E-16},
+        {-5.000E-01,	 5.000E-01, 	 5.000E-01, 	-5.000E-01},
+        {-5.000E-01,	-5.000E-01, 	 5.000E-01, 	-5.000E-01},
+        { 6.123E-17,	 0.000E+00, 	 0.000E+00, 	 1.000E+00},
+        {-5.000E-01,	 5.000E-01, 	-5.000E-01, 	 5.000E-01},
+        {-5.000E-01,	 5.000E-01, 	-5.000E-01, 	-5.000E-01},
+        {-8.660E-17,	 7.071E-01, 	-7.071E-01, 	 6.123E-17},
+        {-1.421E-16,	 7.071E-01, 	-1.110E-16, 	-7.071E-01},
+        {-5.551E-17,	 1.910E-16, 	 7.071E-01, 	-7.071E-01},
+        {-7.071E-01,	 0.000E+00, 	 0.000E+00, 	 7.071E-01},
+        {-7.071E-01,	 7.177E-17, 	-7.071E-01, 	 1.340E-16},
+        {-3.005E-16,	 5.551E-17, 	-7.071E-01, 	-7.071E-01},
+        {-1.045E-16,	 1.009E-16, 	-1.000E+00, 	-1.793E-17},
+        { 5.000E-01,	 5.000E-01, 	-5.000E-01, 	-5.000E-01},
+        { 5.000E-01,	 5.000E-01, 	 5.000E-01, 	-5.000E-01}
+      }; // 24 symmetric for fcc
+
+    std::vector<QuatReal> q(q_num.size());
+    for (const auto i : index_range(q_num))
+    {
+      q[i].w() = q_num[i][0];
+      q[i].x() = q_num[i][1];
+      q[i].y() = q_num[i][2];
+      q[i].z() = q_num[i][3];
+    }
+    return q;
+  }
+
+  Real dotQuaternion(const QuatReal & o1, const QuatReal & o2, 
+                                              const std::vector<QuatReal> & qcs, 
+                                              const std::vector<QuatReal> & qss)
+  {
+    Real d = 0.0; // used to get misorientation angle
+    QuatReal mori = itimesQuaternion(o1, o2);
+
+    if (qss.size() <= 1)
+      d = dotOuterQuaternion(mori, qcs); 
+    else
+      d = mtimes2Quaternion(o1, qcs, o2);
+
+    return d;
+  }
+
+  QuatReal itimesQuaternion(const QuatReal & q1, const QuatReal & q2)
+  {
+    Real a1, b1, c1, d1;
+    Real a2, b2, c2, d2;
+
+    a1 = q1.w(); b1 = -q1.x(); c1 = -q1.y(); d1 = -q1.z();
+    a2 = q2.w(); b2 = q2.x(); c2 = q2.y(); d2 = q2.z();
+
+    // standard algorithm
+    QuatReal q;
+    q.w() = a1 * a2 - b1 * b2 - c1 * c2 - d1 * d2;
+    q.x() = b1 * a2 + a1 * b2 - d1 * c2 + c1 * d2;
+    q.y() = c1 * a2 + d1 * b2 + a1 * c2 - b1 * d2;
+    q.z() = d1 * a2 - c1 * b2 + b1 * c2 + a1 * d2;
+
+    return q;
+  }
+
+  Real dotOuterQuaternion(const QuatReal & rot1, const std::vector<QuatReal> & rot2)
+  {
+    Real d = 0;
+    Real temp = 0;
+    for (const auto i : index_range(rot2))
+    {
+      temp = std::abs(rot1.w()*rot2[i].w() + rot1.x()*rot2[i].x() + rot1.y()*rot2[i].y() + rot1.z()*rot2[i].z()); // rot1 * rot2'
+      if (temp > d)
+        d = temp;
+    }
+
+    return d;
+  }
+
+  Real mtimes2Quaternion(const QuatReal & q1, const std::vector<QuatReal> & q2, const QuatReal & qTwin)
+  {
+    // step 1 -- q1-o1(1*4), q2'-qcs'(4*12)
+    std::vector<QuatReal> q_s1(q2.size());
+    for (unsigned int j = 0; j < q2.size(); ++j)
+    {
+      q_s1[j].w() = q1.w()*q2[j].w() - q1.x()*q2[j].x() - q1.y()*q2[j].y() - q1.z()*q2[j].z();
+      q_s1[j].x() = q1.x()*q2[j].w() + q1.w()*q2[j].x() - q1.z()*q2[j].y() + q1.y()*q2[j].z();
+      q_s1[j].y() = q1.y()*q2[j].w() + q1.z()*q2[j].x() + q1.w()*q2[j].y() - q1.x()*q2[j].z();
+      q_s1[j].z() = q1.z()*q2[j].w() - q1.y()*q2[j].x() + q1.x()*q2[j].y() + q1.w()*q2[j].z();
+    }
+
+    // step 2 -- q1-qcs(12*4), q2'-q_s1'(1*12)
+    std::vector<std::vector<QuatReal>> q_s2(q2.size());
+    for (unsigned int i = 0; i < q2.size(); ++i)
+      q_s2[i].resize(q2.size());
+
+    for (unsigned int i = 0; i < q2.size(); ++i)
+      for (unsigned int j = 0; j < q2.size(); ++j)
+      {
+        q_s2[i][j].w() = q2[i].w()*q_s1[j].w() - q2[i].x()*q_s1[j].x() - q2[i].y()*q_s1[j].y() - q2[i].z()*q_s1[j].z();
+        q_s2[i][j].x() = q2[i].x()*q_s1[j].w() + q2[i].w()*q_s1[j].x() - q2[i].z()*q_s1[j].y() + q2[i].y()*q_s1[j].z();
+        q_s2[i][j].y() = q2[i].y()*q_s1[j].w() + q2[i].z()*q_s1[j].x() + q2[i].w()*q_s1[j].y() - q2[i].x()*q_s1[j].z();
+        q_s2[i][j].z() = q2[i].z()*q_s1[j].w() - q2[i].y()*q_s1[j].x() + q2[i].x()*q_s1[j].y() + q2[i].w()*q_s1[j].z();      
+      }
+    
+    // inline dot_outer(o1,o2) and find max d_vec
+    Real d_max = 0.0;
+    std::vector<std::vector<Real>> d_vec(q2.size());
+    for (unsigned int i = 0; i < q2.size(); ++i)
+      d_vec[i].resize(q2.size());
+
+    for (unsigned int i = 0; i < q2.size(); ++i)
+      for (unsigned int j = 0; j < q2.size(); ++j)
+      {
+        d_vec[i][j] = std::abs(qTwin.w()*q_s2[i][j].w() + qTwin.x()*q_s2[i][j].x() + qTwin.y()*q_s2[i][j].y() + qTwin.z()*q_s2[i][j].z());
+        if (d_max < d_vec[i][j])
+          d_max = d_vec[i][j];
+      }
+    return d_max;
+  }
+}


### PR DESCRIPTION
## Reason
This pull request introduces a new feature to MOP-PF grain growth model that could consider GB anisotropy based on orientation difference

## Design
First, `MisoriAngleCalculator` calculates the orientation difference between two grains; then calculates GB energy and GB energy modify corresponding to different orientation differences based on `GBAnisotropyMisori` + `GBAnisotropyMisoriBase`.

## Impact
The current changes have no impact on the overall framework.


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
